### PR TITLE
Old snapshot no longer hosted;Pick up olap from filesystem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,11 +423,15 @@
                 <groupId>org.olap4j</groupId>
                 <artifactId>olap4j</artifactId>
                 <version>TRUNK-SNAPSHOT</version>
+                <scope>system</scope>
+                <systemPath>${env.PWD}/olap4j_patch/olap4j-TRUNK-SNAPSHOT.jar</systemPath>
             </dependency>
             <dependency>
               <groupId>org.olap4j</groupId>
               <artifactId>olap4j-xmla</artifactId>
               <version>TRUNK-SNAPSHOT</version>
+              <scope>system</scope>
+              <systemPath>${env.PWD}/olap4j_patch/olap4j-xmla-TRUNK-SNAPSHOT.jar</systemPath>
             </dependency>
             <dependency>
               <groupId>org.olap4j</groupId>
@@ -986,7 +990,7 @@
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox-app</artifactId>
-                <version>2.0.0-SNAPSHOT</version>
+                <version>2.0.0</version>
             </dependency>
             <dependency>
                 <groupId>pentaho</groupId>


### PR DESCRIPTION
These changes were necessary to compile saiku-server on a fresh environment.

The olap change eliminates the need to install the artifact into local Maven repository. This is a cleaner solution that will not affect other builds on the same environment
